### PR TITLE
Update DbProfilerServiceProvider.php

### DIFF
--- a/src/DbProfilerServiceProvider.php
+++ b/src/DbProfilerServiceProvider.php
@@ -51,7 +51,7 @@ class DbProfilerServiceProvider extends ServiceProvider
 
         $placeholder = preg_quote('?', '/');
         foreach ($bindings as $binding) {
-            $binding = is_numeric($binding) ? $binding : "'{$binding}'";
+            $binding = gettype($binding) !== 'string' ? $binding : "'{$binding}'";
             $sql = preg_replace('/' . $placeholder . '/', $binding, $sql, 1);
         }
 


### PR DESCRIPTION
also should add quote on numeric strings.

ie: select name from user where user_id='1122222' while the user_id is string